### PR TITLE
Fix model target alignment (Issue #66)

### DIFF
--- a/qusa/model/backtest.py
+++ b/qusa/model/backtest.py
@@ -91,8 +91,12 @@ class ModelBacktester:
         results.loc[results["probability_up"] <= (1 - self.threshold), "signal"] = -1
 
         # calculate returns per trade
-        # Overnight return = (Open_t+1 - Close_t) / Close_t
-        results["overnight_return"] = results["overnight_delta"] / 100
+        # Overnight return for signal at Day T is (Open_T+1 - Close_T) / Close_T
+        # In our data, this is the 'overnight_delta' of the NEXT row.
+        results["overnight_return"] = results["overnight_delta"].shift(-1) / 100
+
+        # Drop the last row as we don't have the next day's open yet
+        results = results.iloc[:-1]
 
         # simulate strategy
         results["strategy_return"] = 0.0

--- a/qusa/model/train.py
+++ b/qusa/model/train.py
@@ -166,7 +166,14 @@ class OvernightDirectionModel:
         ###
 
         logger.info("Preparing data...")
-        data["target"] = (data["overnight_delta"] > 0).astype(int)
+        # SHIFT TARGET: We want Day T features to predict Day T+1 overnight movement.
+        # Since 'overnight_delta' in the CSV is (Open_T - Close_T-1), 
+        # we shift it back by 1 so the target for row T is the jump at T+1.
+        data["target"] = (data["overnight_delta"].shift(-1) > 0).astype(int)
+        
+        # Drop the last row as we don't know the next day's open yet
+        data = data.iloc[:-1]
+
         data = data.dropna(subset=["overnight_delta"])
         data = data.drop(columns=CONFOUND_FEATURES, errors="ignore")
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -14,7 +14,7 @@ os.environ.setdefault("POLYGON_API_KEY", "dummy-key-for-tests")
 
 from qusa.features.monte_carlo import MonteCarloFeatures
 from qusa.features.pipeline import FeaturePipeline
-from qusa.model.train import get_safe_features, prepare_model_features, OvernightDirectionModel
+from qusa.model.train import get_safe_features, prepare_model_features, OvernightDirectionModel, SAFE_FEATURES
 from qusa.utils.config import load_config
 from qusa.analysis.clustering import ClusterAnalyzer
 from qusa.model.evaluate import ModelEvaluator
@@ -532,3 +532,35 @@ def test_mc_index_alignment():
     # 500 + 252 = 752. Rows 500 to 751 are NaN.
     assert result.loc[500:751, "mc_1d_q5"].isna().all()
     assert result.loc[752:999, "mc_1d_q5"].notna().all()
+
+
+def test_model_target_alignment_shifting(tmp_path):
+    """Task 66: Verify model target is shifted to predict NEXT day."""
+    from qusa.model.train import OvernightDirectionModel
+    
+    # Create dummy data
+    data = pd.DataFrame({
+        "date": ["2024-01-01", "2024-01-02", "2024-01-03"],
+        "overnight_delta": [1.0, -2.0, 3.0],  # Day 1: UP, Day 2: DOWN, Day 3: UP
+        "close": [100, 101, 102],
+        "open": [101, 99, 103],
+        "volume": [1000, 1100, 1200]
+    })
+    
+    # Add dummy technical features
+    for f in SAFE_FEATURES:
+        if f not in data.columns:
+            data[f] = 0.0
+            
+    csv_path = tmp_path / "test_alignment.csv"
+    data.to_csv(csv_path, index=False)
+    
+    # Load data via model
+    prepared_data = OvernightDirectionModel.load_data(str(csv_path))
+    
+    # Target for Day 1 should be the delta of Day 2 (Negative -> 0)
+    # Target for Day 2 should be the delta of Day 3 (Positive -> 1)
+    # Day 3 should be dropped (no next day)
+    assert len(prepared_data) == 2
+    assert prepared_data.iloc[0]["target"] == 0
+    assert prepared_data.iloc[1]["target"] == 1


### PR DESCRIPTION
- Shifted target in `train.py`: Day `T` features now predict Day `T+1` overnight jump.
- Re-aligned backtester: signals at close T now capture returns of `T+1`.
- Added `test_model_target_alignment_shifting` to verify logic.
- Removed look-ahead bias from predictive pipeline.