### PR TITLE
Fix data persistence bug for daily fetches (Issue #70)

### DIFF
--- a/qusa/data/loader.py
+++ b/qusa/data/loader.py
@@ -53,7 +53,7 @@ class DataLoader:
         pattern = str(self.raw_dir / f"{ticker}_*.csv")
         all_files = glob.glob(pattern)
         
-        exclude_suffixes = ["_processed.csv", "_clustered.csv", "_latest.csv", "_history.csv"]
+        exclude_suffixes = ["_processed.csv", "_clustered.csv", "_history.csv"]
         source_files = [
             f for f in all_files 
             if not any(f.endswith(suffix) for suffix in exclude_suffixes)
@@ -139,18 +139,12 @@ class DataLoader:
         self.logger.info(f"✓ Latest day fetched → {latest_df['date'].iloc[0]}")
 
         # 2. Consolidate everything
+        # This now picks up the _latest.csv file and merges it into history
         history, _ = self.consolidate_history(ticker)
         
-        # 3. Manually merge the latest day which was just saved to _latest.csv 
-        # (Note: consolidate_history excludes _latest.csv from its scan)
-        if history.empty:
-            merged = latest_df
-        else:
-            merged = pd.concat([history, latest_df], ignore_index=True)
-            
-        merged["date"] = pd.to_datetime(merged["date"])
+        history["date"] = pd.to_datetime(history["date"])
         final = (
-            merged.drop_duplicates(subset=["date"])
+            history.drop_duplicates(subset=["date"])
             .sort_values("date")
             .reset_index(drop=True)
         )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -360,8 +360,9 @@ def test_data_loader_merges_latest_onto_history(monkeypatch, tmp_path):
             "AMZN", start="2026-01-01", end="2026-12-31"
         )
 
-    # Latest day file should exist
-    assert (raw_dir / "AMZN_latest.csv").exists()
+    # Latest day file should be archived (not in raw)
+    assert not (raw_dir / "AMZN_latest.csv").exists()
+    assert (raw_dir / "archive" / "AMZN_latest.csv").exists()
 
     # Merged result should have 4 rows (3 history + 1 new), sorted by date
     assert len(merged) == 4
@@ -564,3 +565,40 @@ def test_model_target_alignment_shifting(tmp_path):
     assert len(prepared_data) == 2
     assert prepared_data.iloc[0]["target"] == 0
     assert prepared_data.iloc[1]["target"] == 1
+
+
+def test_data_loader_persists_latest_fetch(monkeypatch, tmp_path):
+    """Task 70: Verify that _latest.csv is merged into history permanently."""
+    monkeypatch.setenv("POLYGON_API_KEY", "test-key")
+    from qusa.data.loader import DataLoader
+
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    
+    # 1. Create initial history
+    history = pd.DataFrame({
+        "date": ["2024-01-01"],
+        "open": [100.0], "high": [101.0], "low": [99.0], "close": [100.5], "volume": [1000]
+    })
+    history_path = raw_dir / "AAPL_history.csv"
+    history.to_csv(history_path, index=False)
+
+    # 2. Mock fetch_latest_day to return 2024-01-02
+    latest_day = pd.DataFrame({
+        "date": ["2024-01-02"],
+        "open": [100.5], "high": [102.0], "low": [100.0], "close": [101.5], "volume": [1100]
+    })
+    
+    with patch("qusa.data.fetcher.PolygonFetcher.fetch_latest_day", return_value=latest_day):
+        loader = DataLoader(raw_data_dir=str(raw_dir))
+        # This calls fetch_latest_day and then consolidate_history
+        result = loader.load_most_recent("AAPL")
+
+    # 3. Check result
+    assert len(result) == 2
+    assert "2024-01-02" in result["date"].values
+
+    # 4. CRITICAL CHECK: Verify history file on disk now contains BOTH days
+    persisted_history = pd.read_csv(history_path)
+    assert len(persisted_history) == 2
+    assert "2024-01-02" in persisted_history["date"].values


### PR DESCRIPTION
- Removed _latest.csv from exclusion list in consolidate_history.
- Simplified load_most_recent to utilize consolidation for persistence.
- Added test_data_loader_persists_latest_fetch to verify disk persistence.
- Updated existing tests to reflect new archival behavior.